### PR TITLE
fix: replace broken discord cdn links with github links

### DIFF
--- a/docs/incidents/lucas-ggn.md
+++ b/docs/incidents/lucas-ggn.md
@@ -16,28 +16,28 @@ Lucasn0tch will probably not get his own article (I doubt anyone would want to w
 > It was a typical Wednesday afternoon in the Snackbox discord when suddenly....
 
 
-![](https://media.discordapp.net/attachments/1017600763029114883/1022706296992047124/unknown.png)
+![](https://github.com/snackbxx/lore/assets/61562681/419159ad-008b-476c-bcbc-41fd54ad00c5)
 
 **FACT CHECK?**
 
-![](https://media.discordapp.net/attachments/1022708000391188490/1022710051892367370/unknown.png)
+![](https://github.com/snackbxx/lore/assets/61562681/6b0920cf-076d-4fa5-83ac-7e17a1978ae8)
 
 > Hold on, I'm getting a flashback... Something that happened earlier that day...
 
-![](https://media.discordapp.net/attachments/1022708000391188490/1022708010033877032/unknown.png)
+![](https://github.com/snackbxx/lore/assets/61562681/b9a95ac4-599f-4338-9c32-1a523bf834a2)
 
 > To the surprise of no one, doing something this retarded ended up getting him disabled...
 
-![](https://media.discordapp.net/attachments/1022708000391188490/1022708560964112444/unknown.png?width=755&height=586)
-![](https://media.discordapp.net/attachments/1022708000391188490/1022709499963920464/unknown.png?width=851&height=702)
+![](https://github.com/snackbxx/lore/assets/61562681/bce4a5db-b1e6-4287-8a11-10e8dbca9848)
+![](https://github.com/snackbxx/lore/assets/61562681/b036afde-8213-425c-8b6f-89db1e344193)
 
 ## Aftermath (memes)
 
-![](https://media.discordapp.net/attachments/1022708000391188490/1022710465077456967/unknown.png)
-![](https://media.discordapp.net/attachments/1022708000391188490/1022710932574572584/unknown.png?width=628&height=586)
-![](https://media.discordapp.net/attachments/1022708000391188490/1022711274611683328/unknown.png)
-![](https://media.discordapp.net/attachments/1022708000391188490/1022711693643612250/unknown.png)
-![](https://media.discordapp.net/attachments/1022708000391188490/1022711996765962250/unknown.png)
-![](https://media.discordapp.net/attachments/1022708000391188490/1022712622103150633/unknown.png)
-![](https://media.discordapp.net/attachments/1022708000391188490/1022712977788502066/unknown.png)
-![](https://media.discordapp.net/attachments/1022708000391188490/1022713261608677397/unknown.png)
+![](https://github.com/snackbxx/lore/assets/61562681/c6358001-5d3c-4a04-a9b7-d3eceab91d5f)
+![](https://github.com/snackbxx/lore/assets/61562681/2cc0add1-a185-4544-8b3b-a78e04fb461e)
+![](https://github.com/snackbxx/lore/assets/61562681/5ba1e6cf-72d9-4a28-8b74-a4f7b082b9d4)
+![](https://github.com/snackbxx/lore/assets/61562681/e95b79bf-0b06-4248-afe8-0d8584f9370b)
+![](https://github.com/snackbxx/lore/assets/61562681/8fa9301c-f839-4731-9a89-8cb053147399)
+![](https://github.com/snackbxx/lore/assets/61562681/434aed85-a8b5-460f-b8d3-1091f0a05adf)
+![](https://github.com/snackbxx/lore/assets/61562681/c09b50ee-c795-447e-9c7c-feb640452803)
+![](https://github.com/snackbxx/lore/assets/61562681/72fd4118-c5bf-4290-84b2-b4da0b77ea68)

--- a/docs/incidents/sims.md
+++ b/docs/incidents/sims.md
@@ -14,9 +14,9 @@ A user named JadeHawk joins the r/ap server and has his first post in the Techno
 
 ## Archived images
 
-![](https://media.discordapp.net/attachments/1022708000391188490/1024800054978019419/unknown.png)
-![](https://media.discordapp.net/attachments/1022708000391188490/1024800268094804048/unknown.png)
-![](https://media.discordapp.net/attachments/1022708000391188490/1024800569442975794/unknown.png)
-![](https://media.discordapp.net/attachments/1022708000391188490/1024800812989419552/unknown.png)
-![](https://media.discordapp.net/attachments/1022708000391188490/1024800993541636217/unknown.png)
-![](https://media.discordapp.net/attachments/1022708000391188490/1024801057223741481/unknown.png)
+![](https://github.com/snackbxx/lore/assets/61562681/41e14164-7e9e-49d8-878d-86af4d78d9f1)
+![](https://github.com/snackbxx/lore/assets/61562681/7109f138-fc8b-41dd-9a58-0aa793973c46)
+![](https://github.com/snackbxx/lore/assets/61562681/851318e5-3148-4db3-9145-4ec46f9d00a0)
+![](https://github.com/snackbxx/lore/assets/61562681/b0a6100c-56e2-4336-816c-ccf02a08465e)
+![](https://github.com/snackbxx/lore/assets/61562681/ca54c56c-27f5-4416-843a-3e9d24a9a3cf)
+![](https://github.com/snackbxx/lore/assets/61562681/5c094ee2-692c-4644-8efa-f8bae7090545)


### PR DESCRIPTION
image links using discord cdn was broken, so replaced them with links using githubs cdn instead.